### PR TITLE
Store the logs of the download PowerShell example in files

### DIFF
--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -31,7 +31,7 @@ try {
     $logConfig = [ConfigurationManager]::GetLogConfiguration(($_configPath))
 }
 catch {
-    [Helper]::EndProgramWithError($_, "Failure retrieving the configuration. Tip: see the README.MD to check the format of the parameters.", $null)
+    [Helper]::EndProgramWithError($_, "Failure retrieving the logger configuration. Tip: see the README.MD to check the format of the parameters.", $null)
 }
 
 [Logger] $logger = [Logger]::new($logConfig.Enabled, $logConfig.Path)
@@ -621,7 +621,9 @@ class Helper {
     }
 
     static [void] EndProgramWithError([System.Management.Automation.ErrorRecord] $errorRecord, [string] $genericErrorMessage, [Logger] $logger) {
-        if (!$logger) { $logger = [Logger]::new($false) }
+        if (-not $logger) {
+            $logger = [Logger]::new($false, "")
+        }
 
         $logger.LogError($genericErrorMessage)
 
@@ -646,7 +648,9 @@ class Helper {
     }
 
     hidden static [void] FinishProgram([bool] $finishWithError, [Logger] $logger) {
-        if (!$logger) { $logger = [Logger]::new($false) }
+        if (-not $logger) {
+            $logger = [Logger]::new($false, "")
+        }
 
         $logger.LogInformation("----")
         $logger.LogInformation("End of the example.`n")

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -31,10 +31,10 @@ try {
     $logConfig = [ConfigurationManager]::GetLogConfiguration(($_configPath))
 }
 catch {
-    [Helper]::EndProgramWithError($_, "Failure retrieving the configuration. Tip: see the README.MD to check the format of the parameters.")
+    [Helper]::EndProgramWithError($_, "Failure retrieving the configuration. Tip: see the README.MD to check the format of the parameters.", $null)
 }
 
-[Logger] $logger = [Logger]::new($logConfig.Logs.Enabled, $logConfig.Logs.Path)
+[Logger] $logger = [Logger]::new($logConfig.Enabled, $logConfig.Path)
 
 #endregion Log configuration
 
@@ -560,7 +560,7 @@ class Logger {
         $this._storeLogs = $storeLogs
 
         if ($storeLogs) {
-            $this._logPath = Join-Path $logsDirectory "download log - $([Helper]::NewUtcDate("yyyy-MM-dd"))"
+            $this._logPath = Join-Path $logsDirectory "download log - $([Helper]::NewUtcDate("yyyy-MM-dd")).txt"
         
             if (-not (Test-Path -Path $logsDirectory -PathType Container)) {
                 New-Item -ItemType Directory -Path $logsDirectory -Force
@@ -573,7 +573,7 @@ class Logger {
         
         Write-Host $text
         if ($this._storeLogs) {
-            $text | Out-File $this._logPath -Append -Force
+            $text | Out-File $this._logPath -Encoding utf8 -Append -Force
         }
     }
 
@@ -582,7 +582,7 @@ class Logger {
 
         Write-Host $text -ForegroundColor "Red"
         if ($this._storeLogs) {
-            $text | Out-File $this._logPath -Append -Force
+            $text | Out-File $this._logPath -Encoding utf8 -Append -Force
         }
     }
 }
@@ -623,7 +623,7 @@ class Helper {
     static [void] EndProgramWithError([System.Management.Automation.ErrorRecord] $errorRecord, [string] $genericErrorMessage, [Logger] $logger) {
         if (!$logger) { $logger = [Logger]::new($false) }
 
-        $logger.LogError("ERROR - $($genericErrorMessage)")
+        $logger.LogError($genericErrorMessage)
 
         $errorMessage = "Unknown error."
         if ($errorRecord.ErrorDetails.Message) {
@@ -642,14 +642,14 @@ class Helper {
         $logger.LogError("| Error message: $($errorMessage)")
         $logger.LogError("| Error line in the script: $($errorRecord.InvocationInfo.ScriptLineNumber)")
 
-        [Helper]::FinishProgram($true)
+        [Helper]::FinishProgram($true, $logger)
     }
 
     hidden static [void] FinishProgram([bool] $finishWithError, [Logger] $logger) {
         if (!$logger) { $logger = [Logger]::new($false) }
-        
+
         $logger.LogInformation("----")
-        $logger.LogInformation("End of the example.")
+        $logger.LogInformation("End of the example.`n")
 
         if ($finishWithError) {
             exit 1

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -38,9 +38,9 @@ catch {
 
 #endregion Log configuration
 
-$logger.LogInformation("=========================================================")
-$logger.LogInformation("File API example: Download files specified in a filter.")
-$logger.LogInformation("=========================================================")
+$logger.LogInformation("==============================================")
+$logger.LogInformation("File API integration example: Download files.")
+$logger.LogInformation("==============================================")
 
 $logger.LogInformation("(you can stop the script at any moment by pressing the buttons 'CTRL'+'C')")
 

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -558,7 +558,7 @@ class Logger {
     Logger([bool] $storeLogs, [string] $logsDirectory) {
         $this._storeLogs = $storeLogs
 
-        if ($storeLogs) {
+        if ($this._storeLogs) {
             $this._logPath = Join-Path $logsDirectory "download log - $([Helper]::NewUtcDate("yyyy-MM-dd")).txt"
         
             if (-not (Test-Path -Path $logsDirectory -PathType Container)) {

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -42,6 +42,7 @@ $logger.LogInformation("==============================================")
 $logger.LogInformation("File API integration example: Download files.")
 $logger.LogInformation("==============================================")
 $logger.LogInformation("(you can stop the script at any moment by pressing the buttons 'CTRL'+'C')")
+$logger.LogInformation("PowerShell version: $($global:PSVersionTable.PSVersion)")
 
 #region Rest of the configuration
 

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -41,7 +41,6 @@ catch {
 $logger.LogInformation("==============================================")
 $logger.LogInformation("File API integration example: Download files.")
 $logger.LogInformation("==============================================")
-
 $logger.LogInformation("(you can stop the script at any moment by pressing the buttons 'CTRL'+'C')")
 
 #region Rest of the configuration

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -13,7 +13,7 @@ Param(
     [Alias("RenewCredentials")]
     [Parameter(
         Mandatory = $false,
-        HelpMessage = 'Boolean. $true if you want to renew your credentials. $false otherwise'
+        HelpMessage = 'Boolean. $true if you want to renew your credentials. $false otherwise.'
     )]
     [bool] $_renewCredentials = $false
 )
@@ -129,7 +129,11 @@ class ConfigurationManager {
     
         $fileApiBaseUrl = $config.Services.FileApiBaseUrl
         $authenticationTokenApiBaseUrl = $config.Services.AuthenticationTokenApiBaseUrl
+        
         $vismaConnectTenantId = $config.Authentication.VismaConnectTenantId
+
+        $enableLogs = $config.Logs.Enabled
+        $logsPath = $config.Logs.Path
 
         $role = $Config.Download.Role
         $downloadPath = $config.Download.Path
@@ -141,6 +145,8 @@ class ConfigurationManager {
         if ([string]::IsNullOrEmpty($fileApiBaseUrl)) { $missingConfiguration += "Services.FileApiBaseUrl" }
         if ([string]::IsNullOrEmpty($authenticationTokenApiBaseUrl)) { $missingConfiguration += "Services.AuthenticationTokenApiBaseUrl" }
         if ([string]::IsNullOrEmpty($vismaConnectTenantId)) { $missingConfiguration += "Authentication.VismaConnectTenantId" }
+        if ([string]::IsNullOrEmpty($enableLogs)) { $missingConfiguration += "Logs.Enabled" }
+        if ([string]::IsNullOrEmpty($logsPath)) { $missingConfiguration += "Logs.Path" }
         if ([string]::IsNullOrEmpty($role)) { $missingConfiguration += "Download.Role" }
         if ([string]::IsNullOrEmpty($downloadPath)) { $missingConfiguration += "Download.Path" }
         if ([string]::IsNullOrEmpty($ensureUniqueNames)) { $missingConfiguration += "Download.EnsureUniqueNames" }
@@ -154,8 +160,10 @@ class ConfigurationManager {
         if (-not [Validator]::IsPath($credentialsPath)) { $wrongConfiguration += "Credentials.Path" }
         if (-not [Validator]::IsUri($fileApiBaseUrl)) { $wrongConfiguration += "Services.FileApiBaseUrl" }
         if (-not [Validator]::IsUri($authenticationTokenApiBaseUrl)) { $wrongConfiguration += "Services.AuthenticationTokenApiBaseUrl" }
-        if (-not [Validator]::IsPath($downloadPath)) { $wrongConfiguration += "Download.Path" }
+        if (-not [Validator]::IsBool($enableLogs)) { $wrongConfiguration += "Logs.Enabled" }
+        if (-not [Validator]::IsPath($logsPath)) { $wrongConfiguration += "Logs.Path" }
         if (-not [Validator]::IsBool($ensureUniqueNames)) { $wrongConfiguration += "Download.EnsureUniqueNames" }
+        if (-not [Validator]::IsPath($downloadPath)) { $wrongConfiguration += "Download.Path" }
     
         if ($wrongConfiguration.Count -gt 0) {
             throw "Wrong configured parameters: $($wrongConfiguration -Join ", ")"
@@ -578,6 +586,11 @@ class ConfigurationSectionCredentials {
 class ConfigurationSectionServices {
     [string] $FileApiBaseUrl
     [string] $AuthenticationTokenApiBaseUrl
+}
+
+class ConfigurationSectionLogs {
+    [string] $Enabled
+    [string] $Path
 }
 
 class ConfigurationSectionDownload {

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -245,7 +245,7 @@ class CredentialsManager {
             $this._logger.LogInformation("Storage credential path doesn't exist. Creating it.")
             $this._logger.LogInformation("| Path: $($storagePath)")
             
-            New-Item -ItemType Directory -Force -Path $storagePath
+            New-Item -ItemType Directory -Path $storagePath -Force
         }
 
         $this._logger.LogInformation("Enter your credentials.")
@@ -347,7 +347,7 @@ class FileApiService {
             $this._logger.LogInformation("Download path doesn't exist. Creating it.")
             $this._logger.LogInformation("| Path: $($path)")
             
-            New-Item -ItemType Directory -Force -Path $path
+            New-Item -ItemType Directory -Path $path -Force
         }
 
         $downloadedFilesCount = 0
@@ -520,14 +520,14 @@ class Validator {
 
 class Logger {
     hidden [bool] $_storeLogs
-    hidden [string] $_logsPath
+    hidden [string] $_logPath
 
-    Logger ([bool] $storeLogs, [string] $logsPath) {
+    Logger ([bool] $storeLogs, [string] $logsDirectory) {
         $this._storeLogs = $storeLogs
-        $this._logsPath = $logsPath
+        $this._logPath = Join-Path $logsDirectory "log - $([Helper]::NewUtcDate("yyyy-MM-dd"))"
         
-        if (-not (Test-Path -Path $this._logsPath -PathType Container)) {
-            New-Item -ItemType Directory -Force -Path $this._logsPath
+        if (-not (Test-Path -Path $logsDirectory -PathType Container)) {
+            New-Item -ItemType Directory -Path $logsDirectory -Force
         }
     }
 
@@ -536,7 +536,7 @@ class Logger {
         
         Write-Host $text
         if ($this._storeLogs) {
-            $text | Out-File $this._logsPath -Append -Force
+            $text | Out-File $this._logPath -Append -Force
         }
     }
 
@@ -545,7 +545,7 @@ class Logger {
 
         Write-Host $text -ForegroundColor "Red"
         if ($this._storeLogs) {
-            $text | Out-File $this._logsPath -Append -Force
+            $text | Out-File $this._logPath -Append -Force
         }
     }
 }

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -28,7 +28,7 @@ if (-not $_configPath) {
 #region Log configuration
 
 try {
-    $logConfig = [ConfigurationManager]::GetLogConfiguration(($_configPath))
+    $logConfig = [ConfigurationManager]::GetLogConfiguration($_configPath)
 }
 catch {
     [Helper]::EndProgramWithError($_, "Failure retrieving the logger configuration. Tip: see the README.MD to check the format of the parameters.", $null)

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -6,7 +6,7 @@ Param(
     [Alias("ConfigPath")]
     [Parameter(
         Mandatory = $false,
-        HelpMessage = 'Full path of the configuration (e.g. C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\config.xml). Default value: set in the code.'
+        HelpMessage = 'Full path of the configuration (e.g. C:\Visma\File API\Ftaas.Examples\powershell\download\config.xml). Default value: set in the code.'
     )]
     [string] $_configPath,
 

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -559,7 +559,7 @@ class Logger {
         $this._storeLogs = $storeLogs
 
         if ($this._storeLogs) {
-            $this._logPath = Join-Path $logsDirectory "download log - $([Helper]::NewUtcDate("yyyy-MM-dd")).txt"
+            $this._logPath = Join-Path $logsDirectory "download log - $(Get-Date -Format "yyyy-MM-dd").txt"
         
             if (-not (Test-Path -Path $logsDirectory -PathType Container)) {
                 New-Item -ItemType Directory -Path $logsDirectory -Force
@@ -568,7 +568,7 @@ class Logger {
     }
 
     [void] LogInformation([string] $text) {
-        $text = "$([Helper]::NewUtcDate("yy/MM/dd HH:mm:ss")) [Information] $($text)"
+        $text = "$(Get-Date -Format "yy/MM/dd HH:mm:ss") [Information] $($text)"
         
         Write-Host $text
         if ($this._storeLogs) {
@@ -577,7 +577,7 @@ class Logger {
     }
 
     [void] LogError([string] $text) {
-        $text = "$([Helper]::NewUtcDate("yy/MM/dd HH:mm:ss")) [Error] $($text)"
+        $text = "$(Get-Date -Format "yy/MM/dd HH:mm:ss") [Error] $($text)"
 
         Write-Host $text -ForegroundColor "Red"
         if ($this._storeLogs) {
@@ -591,7 +591,7 @@ class Helper {
         $fileNameInfo = [Helper]::GetFileNameInfo($fileName)
         $fileNameWithoutExtension = $fileNameInfo.Name
         $fileExtension = $fileNameInfo.Extension
-        $timestamp = [Helper]::NewUtcDate("yyyyMMddTHHmmssffffZ")
+        $timestamp = Get-Date -Format "yyyyMMddTHHmmssffffZ"
     
         $uniqueFileName = "$($fileNameWithoutExtension)_$($timestamp)$($fileExtension)"
         return $uniqueFileName
@@ -609,10 +609,6 @@ class Helper {
         }
     
         return $fileNameInfo
-    }
-
-    static [string] NewUtcDate([string] $format) {
-        return (Get-Date).ToUniversalTime().ToString($format)
     }
 
     static [void] EndProgram([Logger] $logger) {

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -686,7 +686,7 @@ class ConfigurationSectionServices {
 }
 
 class ConfigurationSectionLogs {
-    [string] $Enabled
+    [bool] $Enabled
     [string] $Path
 }
 

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -387,7 +387,7 @@ class FileApiClient {
     ) {
         $this.BaseUrl = $baseUrl
         $this._defaultHeaders = @{
-            "Authorization"    = "Bearer $($token)";
+            "Authorization" = "Bearer $($token)";
         }
     }
 
@@ -503,6 +503,37 @@ class Validator {
     }
 }
 
+class Logger {
+    hidden [bool] $_storeLogs
+    hidden [string] $_logsPath
+
+    Logger ([bool] $storeLogs, [string] $logsPath) {
+        $this._storeLogs = $storeLogs
+        $this._logsPath = $logsPath
+        
+        if (-not (Test-Path -Path $this._logsPath -PathType Container)) {
+            New-Item -ItemType Directory -Force -Path $this._logsPath
+        }
+    }
+
+    [void] LogInformation([string] $text) {
+        $this.Log("[Information] $($text)");
+    }
+
+    [void] LogError([string] $text) {
+        $this.Log("[Error] $($text)");
+    }
+
+    hidden [void] Log([string] $text) {
+        $text = "$([Helper]::GetTimeStamp()) $($text)"
+
+        Write-Host $text
+        if ($this._storeLogs) {
+            $text | Out-File $this._logsPath -Append -Force
+        }
+    }
+}
+
 class Helper {
     static [string] ConverToUniqueFileName([string] $fileName) {
         $fileNameInfo = [Helper]::GetFileNameInfo($fileName)
@@ -526,6 +557,10 @@ class Helper {
         }
     
         return $fileNameInfo
+    }
+
+    static [string] GetTimeStamp() {
+        return (Get-Date).ToUniversalTime().ToString("yy/MM/dd HH:mm:ss")
     }
 
     static [void] EndProgram() {

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -532,7 +532,7 @@ class Logger {
     }
 
     [void] LogInformation([string] $text) {
-        $text = "$([Helper]::GetTimeStamp()) [Information] $($text)"
+        $text = "$([Helper]::NewUtcDate("yy/MM/dd HH:mm:ss")) [Information] $($text)"
         
         Write-Host $text
         if ($this._storeLogs) {
@@ -541,7 +541,7 @@ class Logger {
     }
 
     [void] LogError([string] $text) {
-        $text = "$([Helper]::GetTimeStamp()) [Error] $($text)"
+        $text = "$([Helper]::NewUtcDate("yy/MM/dd HH:mm:ss")) [Error] $($text)"
 
         Write-Host $text -ForegroundColor "Red"
         if ($this._storeLogs) {
@@ -555,7 +555,7 @@ class Helper {
         $fileNameInfo = [Helper]::GetFileNameInfo($fileName)
         $fileNameWithoutExtension = $fileNameInfo.Name
         $fileExtension = $fileNameInfo.Extension
-        $timestamp = Get-Date -Format FileDateTimeUniversal
+        $timestamp = [Helper]::NewUtcDate("yyyyMMddTHHmmssffffZ")
     
         $uniqueFileName = "$($fileNameWithoutExtension)_$($timestamp)$($fileExtension)"
         return $uniqueFileName
@@ -575,8 +575,8 @@ class Helper {
         return $fileNameInfo
     }
 
-    static [string] GetTimeStamp() {
-        return (Get-Date).ToUniversalTime().ToString("yy/MM/dd HH:mm:ss")
+    static [string] NewUtcDate([string] $format) {
+        return (Get-Date).ToUniversalTime().ToString($format)
     }
 
     static [void] EndProgram([Logger] $logger) {

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -113,7 +113,7 @@ Inside the **config.xml** file you will find these parameters:
 
 **`Path`**
 > Path where the logs will be stored.  
-> If the attribute **`Logs`**>**`Enabled`** is set to false, this attribute do nothing.
+> If the attribute `Logs`>`Enabled` is set to `false`, this attribute will do nothing.
 > 
 > **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs
 
@@ -131,7 +131,7 @@ Inside the **config.xml** file you will find these parameters:
 **`Path`**
 > Path where the files will be downloaded.
 > 
-> **Example:** C:\Visma\File API\Ftaas.Examples\VismaDeveloperPortal\powershell\download\output
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\output
 
 <br/>
 

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -52,19 +52,19 @@ The next executions will use the saved credentials unless you manually specify t
 #### Example 1. Download files using the default configuration path
 
 ```powershell
-& "C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\DownloadFiles.ps1"
+& "C:\Visma\File API\Ftaas.Examples\powershell\download\DownloadFiles.ps1"
 ```
 
 #### Example 2. Download files specifying the configuration path
 
 ```powershell
-& "C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\DownloadFiles.ps1" -ConfigPath "C:\Users\Foorby\config.xml"
+& "C:\Visma\File API\Ftaas.Examples\powershell\download\DownloadFiles.ps1" -ConfigPath "C:\Users\Foorby\config.xml"
 ```
 
 #### Example 3. Download files using new credentials
 
 ```powershell
-& "C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\DownloadFiles.ps1" -RenewCredentials $true
+& "C:\Visma\File API\Ftaas.Examples\powershell\download\DownloadFiles.ps1" -RenewCredentials $true
 ```
 
 ## Understanding the configuration
@@ -77,7 +77,7 @@ Inside the **config.xml** file you will find these parameters:
 > XML file path where the credentials will be storaged.  
 > :warning: It's important that the file you put in the path has an .xml extension, otherwise the example will not work properly.
 > 
-> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\credentials\credentials_integration1.xml
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\credentials\credentials_integration1.xml
 
 ### Attributes of the `Services` element
 
@@ -115,7 +115,7 @@ Inside the **config.xml** file you will find these parameters:
 > Path where the logs will be stored.  
 > If the attribute **`Logs`**>**`Enabled`** is set to **`false`**, this attribute will do nothing.
 > 
-> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\download\logs
 
 ### Attributes of the `Download` element
 
@@ -131,7 +131,7 @@ Inside the **config.xml** file you will find these parameters:
 **`Path`**
 > Path where the files will be downloaded.
 > 
-> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\output
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\download\output
 
 <br/>
 
@@ -158,7 +158,7 @@ Inside the **config.xml** file you will find these parameters:
 ```xml
 <Configuration>
     <Credentials>
-        <Path>C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\credentials\credentials_integration.xml</Path>
+        <Path>C:\Visma\File API\Ftaas.Examples\powershell\credentials\credentials_integration.xml</Path>
     </Credentials>
 
     <Services>
@@ -172,12 +172,12 @@ Inside the **config.xml** file you will find these parameters:
 
     <Logs>
         <Enabled>true</Enabled>
-        <Path>C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs</Path>
+        <Path>C:\Visma\File API\Ftaas.Examples\powershell\download\logs</Path>
     </Logs>
 
     <Download>
         <Role>subscriber</Role>
-        <Path>C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\output</Path>
+        <Path>C:\Visma\File API\Ftaas.Examples\powershell\download\output</Path>
         <EnsureUniqueNames>true</EnsureUniqueNames>
         <Filter>startsWith(FileName, 'employee_profile') and uploadDate gt 2022-02-08T11:02:00Z</Filter>
     </Download>

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -106,13 +106,13 @@ Inside the **config.xml** file you will find these parameters:
 > Indicates if you want to store the logs in your machine.
 > 
 > Must be set to any of these values:  
-> **· false:** the logs will only be shown in the console.
+> **· false:** the logs will only be shown in the console.  
 > **· true:** the logs will be shown in the console and will be stored in your machine.
 
 <br/>
 
 **`Path`**
-> Path where the logs will be stored.
+> Path where the logs will be stored.  
 > If the attribute **`Logs`**>**`Enabled`** is set to false, this attribute do nothing.
 > 
 > It should be set to **https://connect.visma.com/connect**

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -96,16 +96,33 @@ Inside the **config.xml** file you will find these parameters:
 ### Attributes of the `Authentication` element
 
 **`VismaConnectTenantId`**
-> The Visma developer portal tenant id.
+> The Visma developer portal tenant ID.
 
 <br />
+
+### Attributes of the `Logs` element
+
+**`Enabled`**
+> Indicates if you want to store the logs in your machine.
+> 
+> Must be set to any of these values:
+> **· false:** the logs will only be shown in the console.
+> **· true:** the logs will be shown in the console and will be stored in your machine.
+
+<br/>
+
+**`Path`**
+> Path where the logs will be stored.
+> If the attribute **`Logs`**>**`Enabled`** is set to false, this attribute do nothing.
+> 
+> It should be set to **https://connect.visma.com/connect**
 
 ### Attributes of the `Download` element
 
 **`Role`**
 > Role of your application.
 > 
-> Must be set to any of these values:  
+> Must be set to any of these values:
 > **· Subscriber:** to download files provided to you (the most common scenario).  
 > **· Publisher:** to download files uploaded by you.
 
@@ -121,7 +138,7 @@ Inside the **config.xml** file you will find these parameters:
 **`EnsureUniqueNames`**
 > Indicates if you want to rename the files to be unique before downloading them.
 > 
-> Must be set to any of these values:  
+> Must be set to any of these values:
 > **· false:** the downloaded file will replace any existing file with the same name.  
 > **· true:** the downloaded file will be renamed if there is any existing file with the same name.  
 > &nbsp;&nbsp;Format: {original file name}_{timestamp}.{original extension}  
@@ -152,6 +169,11 @@ Inside the **config.xml** file you will find these parameters:
     <Authentication>
         <VismaConnectTenantId>11111111-1111-1111-1111-111111111111</VismaConnectTenantId>
     </Authentication>
+
+    <Logs>
+        <Enabled>true</Enabled>
+        <Path>C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs</Path>
+    </Logs>
 
     <Download>
         <Role>subscriber</Role>

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -115,7 +115,7 @@ Inside the **config.xml** file you will find these parameters:
 > Path where the logs will be stored.  
 > If the attribute **`Logs`**>**`Enabled`** is set to false, this attribute do nothing.
 > 
-> It should be set to **https://connect.visma.com/connect**
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs
 
 ### Attributes of the `Download` element
 

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -4,6 +4,7 @@ A collection of examples to download files with the File API using **PowerShell*
 
 ## Prerequisites
 
+- To run the script you need administrator privileges.
 - The script was prepared for PowerShell version 5.1 or above. With lower versions it might not work properly.
 - Files to be downloaded cannot be bigger than 2 GB.
 

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -113,7 +113,7 @@ Inside the **config.xml** file you will find these parameters:
 
 **`Path`**
 > Path where the logs will be stored.  
-> If the attribute `Logs`>`Enabled` is set to `false`, this attribute will do nothing.
+> If the attribute **`Logs`**>**`Enabled`** is set to **`false`**, this attribute will do nothing.
 > 
 > **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs
 

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -105,7 +105,7 @@ Inside the **config.xml** file you will find these parameters:
 **`Enabled`**
 > Indicates if you want to store the logs in your machine.
 > 
-> Must be set to any of these values:
+> Must be set to any of these values:  
 > **· false:** the logs will only be shown in the console.
 > **· true:** the logs will be shown in the console and will be stored in your machine.
 
@@ -122,7 +122,7 @@ Inside the **config.xml** file you will find these parameters:
 **`Role`**
 > Role of your application.
 > 
-> Must be set to any of these values:
+> Must be set to any of these values:  
 > **· Subscriber:** to download files provided to you (the most common scenario).  
 > **· Publisher:** to download files uploaded by you.
 
@@ -138,7 +138,7 @@ Inside the **config.xml** file you will find these parameters:
 **`EnsureUniqueNames`**
 > Indicates if you want to rename the files to be unique before downloading them.
 > 
-> Must be set to any of these values:
+> Must be set to any of these values:  
 > **· false:** the downloaded file will replace any existing file with the same name.  
 > **· true:** the downloaded file will be renamed if there is any existing file with the same name.  
 > &nbsp;&nbsp;Format: {original file name}_{timestamp}.{original extension}  

--- a/powershell/VismaDeveloperPortal/download/config.xml
+++ b/powershell/VismaDeveloperPortal/download/config.xml
@@ -14,12 +14,12 @@
 
     <Logs>
         <Enabled>true</Enabled>
-        <Path>EnterTheFolderPathWhereYouWantToStoreTheLogs (e.g. C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs)</Path>
+        <Path>EnterTheFolderPathWhereYouWantToStoreTheLogs (e.g. C:\Visma\File API\Ftaas.Examples\powershell\download\logs)</Path>
     </Logs>
 
     <Download>
         <Role>subscriber</Role>
-        <Path>EnterTheFolderPathWhereYouWantToDownloadTheFilesTo (e.g. C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\output)</Path>
+        <Path>EnterTheFolderPathWhereYouWantToDownloadTheFilesTo (e.g. C:\Visma\File API\Ftaas.Examples\powershell\download\output)</Path>
         <EnsureUniqueNames>true</EnsureUniqueNames>
 
         <!-- Here you can find several examples for filtering the files.

--- a/powershell/VismaDeveloperPortal/download/config.xml
+++ b/powershell/VismaDeveloperPortal/download/config.xml
@@ -12,6 +12,11 @@
         <VismaConnectTenantId>EnterYourVismaConnectTenantId</VismaConnectTenantId>
     </Authentication>
 
+    <Logs>
+        <Enabled>true</Enabled>
+        <Path>EnterTheFolderPathWhereYouWantToStoreTheLogs (e.g. C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\logs)</Path>
+    </Logs>
+
     <Download>
         <Role>subscriber</Role>
         <Path>EnterTheFolderPathWhereYouWantToDownloadTheFilesTo (e.g. C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\download\output)</Path>


### PR DESCRIPTION
Now it's possible to save the logs generated by the download PowerShell scripts in a directory.
A new configuration has been added to enable this feature (see README.md).