### PR TITLE
Store the logs of the upload PowerShell example in files

### DIFF
--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -38,6 +38,7 @@ catch {
 
 #endregion Log configuration
 
+$logger.LogRaw("")
 $logger.LogInformation("==============================================")
 $logger.LogInformation("File API integration example: Download files.")
 $logger.LogInformation("==============================================")
@@ -565,6 +566,13 @@ class Logger {
             if (-not (Test-Path -Path $logsDirectory -PathType Container)) {
                 New-Item -ItemType Directory -Path $logsDirectory -Force
             }
+        }
+    }
+
+    [void] LogRaw([string] $text) {
+        Write-Host $text
+        if ($this._storeLogs) {
+            $text | Out-File $this._logPath -Encoding utf8 -Append -Force
         }
     }
 

--- a/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
+++ b/powershell/VismaDeveloperPortal/download/DownloadFiles.ps1
@@ -657,7 +657,7 @@ class Helper {
         }
 
         $logger.LogInformation("----")
-        $logger.LogInformation("End of the example.`n")
+        $logger.LogInformation("End of the example.")
 
         if ($finishWithError) {
             exit 1

--- a/powershell/VismaDeveloperPortal/download/README.md
+++ b/powershell/VismaDeveloperPortal/download/README.md
@@ -112,7 +112,7 @@ Inside the **config.xml** file you will find these parameters:
 <br/>
 
 **`Path`**
-> Path where the logs will be stored.  
+> Full path of the directory where the log files will be stored.  
 > If the attribute **`Logs`**>**`Enabled`** is set to **`false`**, this attribute will do nothing.
 > 
 > **Example:** C:\Visma\File API\Ftaas.Examples\powershell\download\logs

--- a/powershell/VismaDeveloperPortal/upload/README.md
+++ b/powershell/VismaDeveloperPortal/upload/README.md
@@ -4,9 +4,10 @@ A collection of examples to upload files with the File API using **PowerShell**.
 
 ## Prerequisites
 
+- To run the script you need administrator privileges.
 - The script was prepared for PowerShell version 5.1 or above. With lower versions it might not work properly.
 - Files to be uploaded cannot be bigger than 10 GB.
-- Chunksize is limited to 100 MB (4 MB is suggested as most efficient
+- Chunksize is limited to 100 MB (4 MB is suggested as most efficient)
 
 ## Getting Started
 
@@ -53,19 +54,19 @@ The next executions will use the saved credentials unless you manually specify t
 #### Example 1. Upload files using the default configuration path
 
 ```powershell
-& "C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\upload\UploadFile.ps1"
+& "C:\Visma\File API\Ftaas.Examples\powershell\upload\UploadFile.ps1"
 ```
 
 #### Example 2. Upload files specifying the configuration path
 
 ```powershell
-& "C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\upload\UploadFile.ps1" -ConfigPath "C:\Users\Foorby\config.xml"
+& "C:\Visma\File API\Ftaas.Examples\powershell\upload\UploadFile.ps1" -ConfigPath "C:\Users\Foorby\config.xml"
 ```
 
 #### Example 3. Upload files using new credentials
 
 ```powershell
-& "C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\upload\UploadFile.ps1" -RenewCredentials $true
+& "C:\Visma\File API\Ftaas.Examples\powershell\upload\UploadFile.ps1" -RenewCredentials $true
 ```
 
 ## Understanding the configuration
@@ -78,7 +79,7 @@ Inside the **config.xml** file you will find these parameters:
 > XML file path where the credentials will be stored.  
 > :warning: It's important that the file you put in the path has an .xml extension, otherwise the example will not work properly.
 >
-> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\credentials\credentials_integration.xml
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\upload\credentials\credentials_integration.xml
 
 ### Attributes of the `Services` element
 
@@ -98,9 +99,26 @@ Inside the **config.xml** file you will find these parameters:
 ### Attributes of the `Authentication` element
 
 **`VismaConnectTenantId`**
-> The Visma developer portal tenant id.
+> The Visma developer portal tenant ID.
 
 <br />
+
+### Attributes of the `Logs` element
+
+**`Enabled`**
+> Indicates if you want to store the logs in your machine.
+> 
+> Must be set to any of these values:  
+> **· false:** the logs will only be shown in the console.  
+> **· true:** the logs will be shown in the console and will be stored in your machine.
+
+<br/>
+
+**`Path`**
+> Path where the logs will be stored.  
+> If the attribute **`Logs`**>**`Enabled`** is set to **`false`**, this attribute will do nothing.
+> 
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\upload\logs
 
 ### Attributes of the `Upload` element
 
@@ -114,7 +132,7 @@ Inside the **config.xml** file you will find these parameters:
 **`Path`**
 > Full path of the directory that contains the files to upload
 >
-> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\upload
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\upload\files
 
 <br/>
 
@@ -128,7 +146,7 @@ Inside the **config.xml** file you will find these parameters:
 **`ArchivePath`**
 > Full path of the directory where sussessfully uploaded files will be archived to.
 >
-> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\archive
+> **Example:** C:\Visma\File API\Ftaas.Examples\powershell\upload\archive
 
 <br/>
 
@@ -144,7 +162,7 @@ Inside the **config.xml** file you will find these parameters:
 ```xml
 <Configuration>
     <Credentials>
-        <Path>C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\credentials\credentials_integration1.xml</Path>
+        <Path>C:\Visma\File API\Ftaas.Examples\powershell\upload\credentials\credentials_integration.xml</Path>
     </Credentials>
 
     <Services>
@@ -156,11 +174,16 @@ Inside the **config.xml** file you will find these parameters:
         <VismaConnectTenantId>11111111-1111-1111-1111-111111111111</VismaConnectTenantId>
     </Authentication>
 
+    <Logs>
+        <Enabled>true</Enabled>
+        <Path>C:\Visma\File API\Ftaas.Examples\powershell\upload\logs</Path>
+    </Logs>
+
     <Upload>
         <BusinessTypeId>9890988</BusinessTypeId>
-        <Path>C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\upload</Path>
+        <Path>C:\Visma\File API\Ftaas.Examples\powershell\upload\files</Path>
         <Filter>data*.xml</Filter>
-        <ArchivePath>C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\archive</ArchivePath>
+        <ArchivePath>C:\Visma\File API\Ftaas.Examples\powershell\upload\archive</ArchivePath>
         <Chunksize>4</ChunkSize>
     </Upload>
 </Configuration>

--- a/powershell/VismaDeveloperPortal/upload/README.md
+++ b/powershell/VismaDeveloperPortal/upload/README.md
@@ -90,7 +90,6 @@ Inside the **config.xml** file you will find these parameters:
 
 <br />
 
-
 **`AuthenticationTokenApiBaseUrl`**
 > Authentication token API base URL.
 >
@@ -115,7 +114,7 @@ Inside the **config.xml** file you will find these parameters:
 <br/>
 
 **`Path`**
-> Path where the logs will be stored.  
+> Full path of the directory where the log files will be stored.  
 > If the attribute **`Logs`**>**`Enabled`** is set to **`false`**, this attribute will do nothing.
 > 
 > **Example:** C:\Visma\File API\Ftaas.Examples\powershell\upload\logs

--- a/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
+++ b/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
@@ -41,7 +41,6 @@ catch {
 $logger.LogRaw("")
 $logger.LogInformation("=============================================================")
 $logger.LogInformation("File API integration example: Upload files from a directory.")
-$logger.LogInformation("                              Supports files > 100Mb")
 $logger.LogInformation("=============================================================")
 $logger.LogInformation("(you can stop the script at any moment by pressing the buttons 'CTRL'+'C')")
 $logger.LogInformation("PowerShell version: $($global:PSVersionTable.PSVersion)")

--- a/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
+++ b/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
@@ -329,7 +329,7 @@ class FileApiService {
 
     [PSCustomObject] UploadChunkRequest([string] $fileToken, [string] $filenameToUpload, [long] $chunkNumber) {
         $result = $this.CreateChunk($filenameToUpload, $this._chunkSize, $chunkNumber)
-        $response = $this.UploadFile($result.ChunkPath, $(Split-Path -Path $filenameToUpload -Leaf), "application/octet-stream", $fileToken, $chunkNumber, $result.Eof)
+        $this.UploadFile($result.ChunkPath, $(Split-Path -Path $filenameToUpload -Leaf), "application/octet-stream", $fileToken, $chunkNumber, $result.Eof)
 
         return [PSCustomObject]@{
             Eof = $result.Eof
@@ -380,12 +380,11 @@ class FileApiService {
 
     [PSCustomObject] CreateChunk([string] $contentFilePath, [long] $chunkSize, [long] $chunkNumber) {
         $folderPath = $(Split-Path -Path $contentFilePath)
-        $contentFilename = $(Split-Path -Path $contentFilePath -Leaf)
         $createdChunkPath = "$($folderPath)\$([Helper]::ConvertToUniqueFilename("Chunk_$($chunkNumber).bin"))"
         [byte[]]$bytes = new-object Byte[] $chunkSize
         $fileStream = New-Object System.IO.FileStream($contentFilePath, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read)
         $binaryReader = New-Object System.IO.BinaryReader( $fileStream)
-        $pos = $binaryReader.BaseStream.Seek($chunkNumber * $chunkSize, [System.IO.SeekOrigin]::Begin)
+        $binaryReader.BaseStream.Seek($chunkNumber * $chunkSize, [System.IO.SeekOrigin]::Begin)
         $bytes = $binaryReader.ReadBytes($chunkSize) 
        
         $this._fileBytesRead += $bytes.Length

--- a/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
+++ b/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
@@ -657,7 +657,7 @@ class Logger {
         $this._storeLogs = $storeLogs
 
         if ($this._storeLogs) {
-            $this._logPath = Join-Path $logsDirectory "upload log - $([Helper]::NewUtcDate("yyyy-MM-dd")).txt"
+            $this._logPath = Join-Path $logsDirectory "upload log - $(Get-Date -Format "yyyy-MM-dd").txt"
 
             if (-not (Test-Path -Path $logsDirectory -PathType Container)) {
                 New-Item -ItemType Directory -Path $logsDirectory -Force
@@ -666,7 +666,7 @@ class Logger {
     }
 
     [void] LogInformation([string] $text) {
-        $text = "$([Helper]::NewUtcDate("yy/MM/dd HH:mm:ss")) [Information] $($text)"
+        $text = "$(Get-Date -Format "yy/MM/dd HH:mm:ss") [Information] $($text)"
 
         Write-Host $text
         if ($this._storeLogs) {
@@ -675,7 +675,7 @@ class Logger {
     }
 
     [void] LogError([string] $text) {
-        $text = "$([Helper]::NewUtcDate("yy/MM/dd HH:mm:ss")) [Error] $($text)"
+        $text = "$(Get-Date -Format "yy/MM/dd HH:mm:ss") [Error] $($text)"
 
         Write-Host $text -ForegroundColor "Red"
         if ($this._storeLogs) {
@@ -761,10 +761,6 @@ class Helper {
         }
 
         return $filenameInfo
-    }
-
-    static [string] NewUtcDate([string] $format) {
-        return (Get-Date).ToUniversalTime().ToString($format)
     }
 
     static [void] EndProgram([Logger] $logger) {

--- a/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
+++ b/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
@@ -6,7 +6,7 @@ Param(
     [Alias("ConfigPath")]
     [Parameter(
         Mandatory = $false,
-        HelpMessage = 'Full filePath of the configuration (e.g. C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\upload\config.xml). Default value: set in the code.'
+        HelpMessage = 'Full filePath of the configuration (e.g. C:\Visma\File API\Ftaas.Examples\powershell\upload\config.xml). Default value: set in the code.'
     )]
     [string] $_configPath,
 

--- a/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
+++ b/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
@@ -43,6 +43,7 @@ $logger.LogInformation("File API integration example: Upload files from a direct
 $logger.LogInformation("                              Supports files > 100Mb")
 $logger.LogInformation("=============================================================")
 $logger.LogInformation("(you can stop the script at any moment by pressing the buttons 'CTRL'+'C')")
+$logger.LogInformation("PowerShell version: $($global:PSVersionTable.PSVersion)")
 
 #region Rest of the configuration
 
@@ -457,9 +458,16 @@ class FileApiService {
             $streamEof = 1
         }
 
-        $binaryReader.Dispose()  
+        $binaryReader.Dispose()
 
-        Set-Content -Path $createdChunkPath -Value $bytes -Encoding Byte
+        # The way of encoding the bytes changed in the version 6.0.0. See the following link for more information:
+        # https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.management/set-content?view=powershell-7.3#parameters
+        if ($global:PSVersionTable.PSVersion -ge "6.0.0") {
+            Set-Content -Path $createdChunkPath -Value $bytes -AsByteStream
+        }
+        else {
+            Set-Content -Path $createdChunkPath -Value $bytes -Encoding Byte
+        }
 
         return [PSCustomObject]@{
             ChunkPath = $createdChunkPath

--- a/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
+++ b/powershell/VismaDeveloperPortal/upload/UploadFile.ps1
@@ -772,7 +772,7 @@ class Helper {
         }
 
         $logger.LogInformation("----")
-        $logger.LogInformation("End of the example.")
+        $logger.LogInformation("End of the example.`n")
 
         if ($finishWithError) {
             exit 1

--- a/powershell/VismaDeveloperPortal/upload/config.xml
+++ b/powershell/VismaDeveloperPortal/upload/config.xml
@@ -1,6 +1,6 @@
 <Configuration>
     <Credentials>
-        <Path>EnterTheFilePathWhereYouWantToStoreYourCredentials (e.g. C:\Visma\File API\Ftaas.Examples\powershell\credentials\credentials_integration.xml)</Path>
+        <Path>EnterTheFilePathWhereYouWantToStoreYourCredentials (e.g. C:\Visma\File API\Ftaas.Examples\powershell\upload\credentials\credentials_integration.xml)</Path>
     </Credentials>
 
     <Services>
@@ -12,11 +12,16 @@
         <VismaConnectTenantId>EnterYourVismaConnectTenantId</VismaConnectTenantId>
     </Authentication>
 
+    <Logs>
+        <Enabled>true</Enabled>
+        <Path>EnterTheFolderPathWhereYouWantToStoreTheLogs (e.g. C:\Visma\File API\Ftaas.Examples\powershell\upload\logs)</Path>
+    </Logs>
+
     <Upload>
         <BusinessTypeId>EnterYourBusinessTypeId</BusinessTypeId>
-        <Path>EnterTheDirectoryToUpload (e.g.: C:\Visma\File API\Ftaas.Examples\powershell\upload\VismaDeveloperPortal\file)</Path>
+        <Path>EnterTheDirectoryToUpload (e.g.: C:\Visma\File API\Ftaas.Examples\powershell\upload\files)</Path>
         <Filter>EnterFilemaskToUseForUpload (e.g.: *.xml)</Filter>
-        <ArchivePath>EnterTheDirectoryForArchivedFiles (e.g.: C:\Visma\File API\Ftaas.Examples\powershell\VismaDeveloperPortal\archive)</ArchivePath>
+        <ArchivePath>EnterTheDirectoryForArchivedFiles (e.g.: C:\Visma\File API\Ftaas.Examples\powershell\upload\archive)</ArchivePath>
 	    <ChunkSize>4</ChunkSize>
     </Upload>
 </Configuration>


### PR DESCRIPTION
Now it's possible to save the logs generated by the upload PowerShell scripts in a directory.
A new configuration has been added to enable this feature (see README.md).